### PR TITLE
Fixed baseDir error and allowing custom directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ elixir.extend('stylus', function(src, output) {
 
     var config = this;
 
-    var baseDir = config.preprocessors.baseDir + 'stylus';
+    var stylusDir = config.stylusDir || "stylus";
+
+    var baseDir = config.assetsDir + stylusDir;
 
     src = this.buildGulpSrc(src, baseDir, '**/*.styl');
 

--- a/readme.md
+++ b/readme.md
@@ -23,3 +23,11 @@ Finally, if you'd like to output to a different directory than the default `publ
 ```
 mix.stylus("bootstrap.styl", "public/css/foo/bar/");
 ```
+
+To set a custom directory set the stylusDir
+Note: this directory is appened to the assetsDir and does not require a leading slash
+```
+elixir.stylusDir = 'path/to/stylus/dir';
+mix.stylus("bootstrap.styl");
+```
+


### PR DESCRIPTION
I've updated the index.js file to fix the baseDir error. I've also allowed for a custom directory to be set. 