### PR TITLE
Changed output behavior according to source name

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,10 @@ Elixir.extend('stylus', function(src, output, options) {
  * @return {object}
  */
 var prepGulpPaths = function(src, output) {
+    var baseName = src.split('.')[0];
+
+    output = output || config.get('public.css.outputFolder');
     return new Elixir.GulpPaths()
         .src(src, config.get('assets.css.stylus.folder'))
-        .output(output || config.get('public.css.outputFolder'), 'app.css');
+        .output(output, baseName + '.css');
 };


### PR DESCRIPTION
Hello,

I needed two css output files for a project, and didn't find the output option so easy to use, cause i had to retype all path.
I came up with this simple update such as a call to mix.stylus('other.styl') generates an 'other.css' outuput file in the correct output directory, allowing then to have easily multiple output css

hopefully u'll like this change and accepts it