### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,6 @@ If there are other PostCSS plugins you want to pull in, you may use the third ar
 var postStylus = require('poststylus'); // npm install --save-dev poststylus
 
 mix.stylus('app.styl', null, {
-   use: [postStylus(['lost', 'postcss-position'])]
+   use: [postStylus(['lost', 'postcss-position'])] // npm install --save-dev postcss-position
 });
 ```


### PR DESCRIPTION
If postcss-position is not already installed in your project, gulp will throw the following error: "Cannot find module 'postcss-position'".